### PR TITLE
refactor: Meteor dimensions function now DRYer. 

### DIFF
--- a/lib/meteor.js
+++ b/lib/meteor.js
@@ -1,8 +1,8 @@
 var addImage = require('./images')
 
-function Meteor(board, level, xDim, yDim) {
+function Meteor(board, level) {
   this.board = board;
-  this.size  = this.dimensions(level, xDim, yDim);
+  this.size  = this.dimensions(level);
   this.velocity = this.velocities(level)
 
   var randomXPosition = Math.floor(Math.random() * this.board.width);
@@ -14,20 +14,23 @@ function Meteor(board, level, xDim, yDim) {
   this.image = addImage('meteor');
 }
 
-Meteor.prototype.dimensions = function(level, xDim, yDim){
-  var randomWidth = Math.floor(Math.random() * 40) + 25;
-  var randomHeight = Math.floor(Math.random() * 40) + 25;
-  var randomWidth2 = Math.floor(Math.random() * 25) + 20;
-  var randomHeight2 = Math.floor(Math.random() * 25) + 20;
-  var randomWidth3 = Math.floor(Math.random() * 10) + 15;
-  var randomHeight3 = Math.floor(Math.random() * 10) + 15;
-  if (level < 2) {
-    return { width: xDim || randomWidth, height: yDim || randomHeight};
-  } else if (level >= 2 && level < 4) {
-    return { width: randomWidth2, height: randomHeight2};
-  } else {
-    return { width: randomWidth3, height: randomHeight3};
+Meteor.prototype.dimensions = function(level) {
+  level = level || 1;
+  var randomWidth  = this.determineDimension(level);
+  var randomHeight = this.determineDimension(level);
+  return { width: randomWidth, height: randomHeight};
+}
+
+Meteor.prototype.determineDimension = function(level) {
+  var sizeByLevel = {
+    1: [40, 25],
+    2: [25, 20],
+    3: [25, 20],
+    4: [10, 15],
+    5: [10, 15]
   }
+  return Math.floor(Math.random() * sizeByLevel[level][0])
+                                  + sizeByLevel[level][1];
 }
 
 Meteor.prototype.velocities = function(level) {

--- a/test/board-test.js
+++ b/test/board-test.js
@@ -175,8 +175,8 @@ describe('Board', function() {
 
       meteor2.center.x = 300;
       meteor2.center.y = 300;
-      bullet2.center.x = 310;
-      bullet2.center.y = 310;
+      bullet2.center.x = 300;
+      bullet2.center.y = 300;
 
       meteor3.center.x = 150;
       meteor3.center.y = 150;

--- a/test/meteor-test.js
+++ b/test/meteor-test.js
@@ -36,18 +36,12 @@ describe('Meteor', function() {
       assert.isBelow(this.meteor.size.height, 66);
     });
 
-    it('should have a height and width that can be manually set', function() {
-      let meteor = new Meteor(this.board, 1, 20, 30);
-      assert.equal(meteor.size.width, 20);
-      assert.equal(meteor.size.height, 30);
-    });
-
     it('should have a point value based on its width and height', function() {
-      let meteor = new Meteor(this.board, 1, 20, 30);
-      assert.equal(meteor.pointValue, 41);
+      let meteor = new Meteor(this.board, 1);
+      assert(meteor.pointValue < 40);
 
-      let meteor2 = new Meteor(this.board, 1, 20, 40);
-      assert.equal(meteor2.pointValue, 36);
+      let meteor2 = new Meteor(this.board, 1);
+      assert(meteor2.pointValue < 40);
     });
 
     it('should be included in the board\'s array of this.meteor objects', function() {


### PR DESCRIPTION
closes #6 

Extracted meteor size based on level into separate prototype method, deleted extraneous ability to manually set x and y dimensions of a meteor since the game sets the dimensions by istelf based on the current level

Worked with @ChrisCenatie 

@rrgayhart could you please take a look? Thanks!
